### PR TITLE
export track vertices as csv for napari

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.vscode
+__pycache__

--- a/napatrackmater/Trackmate.py
+++ b/napatrackmater/Trackmate.py
@@ -467,8 +467,11 @@ def ImportTrackmateXML(xml_path, Segimage, XYcalibration = 1, Zcalibration = 1, 
         RegionID = {}
         VolumeID = {}
         locationID = {}    
-        
 
+        Tloc = []
+        Zloc = []
+        Yloc = []
+        Xloc = []
         
         for trackid, DictTrackobjects, DictSpeedobjects, Trackobjects, Trackletobjects, SortedTracklets, tstart in Tracks:
             
@@ -477,17 +480,13 @@ def ImportTrackmateXML(xml_path, Segimage, XYcalibration = 1, Zcalibration = 1, 
              VolumeID[trackid] = [trackid]
              locationID[trackid] = [trackid]
              StartID[trackid] = [trackid]
-             ID.append(trackid)
              TrackletRegionID = {}
              TrackletVolumeID = {}
              TrackletlocationID = {}
              
              StartID[trackid].append(tstart)
              
-             Tloc = []
-             Zloc = []
-             Yloc = []
-             Xloc = []
+
              Speedloc = []
              DistanceBoundary = []
              ProbabilityInside = []
@@ -520,6 +519,7 @@ def ImportTrackmateXML(xml_path, Segimage, XYcalibration = 1, Zcalibration = 1, 
                                            
                                           
                                            speed = (float(VelocitySpotobject))
+                                           ID.append(trackid)
                                            Tloc.append(t)
                                            Zloc.append(z)
                                            Yloc.append(y)
@@ -607,7 +607,7 @@ def ImportTrackmateXML(xml_path, Segimage, XYcalibration = 1, Zcalibration = 1, 
         df = pd.DataFrame(list(zip(ID,Tloc,Zloc,Yloc,Xloc)), index = None, 
                                               columns =['ID', 't', 'z', 'y', 'x'])
 
-        df.to_csv(savedir + '/' + 'TrackMate' +  Name +  '.csv')  
+        df.to_csv(savedir + '/' + 'TrackMate' +  Name +  '.csv', index = False)  
         df
 
         return RegionID, VolumeID, locationID, Tracks, ID, StartID


### PR DESCRIPTION
Hi,

sorry that I interrupt again...

I played a little around with the function `ImportTrackmateXML`  and found that the tracks should be exported to a csv-File.

The file, however, only contained a single line (since `Tloc`, `Zloc`, etc. are initialized in every loop).

By reordering the lines, the csv file now contains a complete array of track infromation which is directly usable in napari:

```
import numpy as np
tracks = np.genfromtxt(<savedir/TrackMate{Name}.csv>, delimiter=',', skip_header=1)
viewer.add_tracks(tracks)
```

Best wishes,

Eric
