### PR TITLE
add track console script

### DIFF
--- a/napatrackmater/__main__.py
+++ b/napatrackmater/__main__.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+""" Entrypoint for the CreateTrackCheckpoint command
+"""
+import argparse
+
+from . import bTrackmate
+
+def main():
+    """ Parse arguments and launch processor """
+    parser = argparse.ArgumentParser(
+        description='Create track checkpoint'
+    )
+
+    requiredNamed = parser.add_argument_group('required named arguments')
+
+    requiredNamed.add_argument(
+        '-f',
+        '--folder',
+        metavar='/path/to/output-folder',
+        type=str,
+        help='path to output folder',
+    )
+
+    requiredNamed.add_argument(
+        '-r',
+        '--raw',
+        metavar='/path/to/raw.tif',
+        type=str,
+        help='path to raw tif',
+    )
+
+    requiredNamed.add_argument(
+        '-s',
+        '--seg',
+        metavar='/path/to/seg.tif',
+        type=str,
+        help='path to segmentation tif',
+    )
+
+    requiredNamed.add_argument(
+        '-m',
+        '--mask',
+        metavar='/path/to/mask.tif',
+        type=str,
+        help='path to mask tif',
+    )
+
+    requiredNamed.add_argument(
+        '-n',
+        '--name',
+        metavar='Some name',
+        type=str,
+        help='A name for identification',
+    )
+
+    arguments = parser.parse_args()
+
+    bTrackmate.CreateTrackCheckpoint(arguments.raw, arguments.seg, arguments.mask, arguments.name, arguments.folder)

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,11 @@ setup(
         "imageio_ffmpeg",
         "dask"
     ],
+    entry_points = {
+        'console_scripts': [
+            'track = napatrackmater.__main__:main',
+        ]
+    },
     packages=setuptools.find_packages(),
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
So here is an example of having a console script. After "installing" it with `pipenv run python setup.py develop` one can run:

~~~bash
pipenv run track -h
pipenv run track -f /tmp/out -r examples/data/Raw.tif -s examples/data/Seg.tif -m examples/data/Mask.tif -n yolo
~~~

I named it `track` but it might not be the best name. I have made the arguments mandatory and named. Maybe the `name` could be optional (and if it's None we take the stem from the raw.tif).

Now we don't have to write a script, just call this and it works ;)

Let me know what you think.